### PR TITLE
BREAKING CHANGE: require first argument to be a string

### DIFF
--- a/slug.js
+++ b/slug.js
@@ -31,7 +31,9 @@ function slug(string, opts) {
 }
 
 function slugify(string, opts) {
-    string = string.toString();
+    if (typeof string !== 'string') {
+        throw new Error('slug() requires a string argument')
+    }
     if ('string' === typeof opts)
         opts = {replacement:opts};
     opts = opts || {};

--- a/test/slug.test.js
+++ b/test/slug.test.js
@@ -7,9 +7,13 @@
 const slug = require('../slug');
 
 describe('slug', function() {
-    it('should convert input to string', function() {
-        [slug(1)].should.eql(['1']);
-        return [slug(567890)].should.eql(['567890']);
+    it('requires an argument', function() {
+        try {
+            slug()
+        } catch (err) {
+            return [err.message].should.eql(['slug() requires a string argument'])
+        }
+        throw new Error('should have thrown');
     });
 
     it('should replace whitespaces with replacement', function() {


### PR DESCRIPTION
It doesn't make sense to accept numbers etc. as the string argument.
Enforce requiring a string.

This aligns us with the slugify module and reduces the potential for
games to be played with things like overriding `.toString()` etc.