### PR TITLE
BREAKING CHANGE: do not load/use unicode symbol table

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Slugifies strings, even when they contain Unicode.
 Make strings URL-safe.
 
 - Respects [RFC 3986](https://tools.ietf.org/html/rfc3986)
-- No dependencies (except the Unicode table)
-- Works in browser (window.slug) and AMD/CommonJS-flavoured module loaders (except the Unicode symbols unless you use browserify but who wants to download a ~2mb js file, right?)
+- No dependencies
+- Works in browser (window.slug) and AMD/CommonJS-flavoured module loaders
 
 ```
 npm install slug
@@ -21,9 +21,6 @@ var print = console.log.bind(console, '>')
 print(slug('i ♥ unicode'))
 // > i-love-unicode
 
-print(slug('unicode ♥ is ☢')) // yes!
-// > unicode-love-is-radioactive
-
 print(slug('i ♥ unicode', '_')) // If you prefer something else than `-` as separator
 // > i_love_unicode
 
@@ -31,8 +28,11 @@ slug.charmap['♥'] = 'freaking love' // change default charmap or use option {c
 print(slug('I ♥ UNICODE'))
 // > I-freaking-love-UNICODE
 
-print(slug('☏-Number', {lower: true})) // If you prefer lower case
+print(slug('Telephone-Number')) // lower case by default
 // > telephone-number
+
+print(slug('Telephone-Number', {lower: false})) // If you want to preserve case
+// > Telephone-Number
 
 print(slug('i <3 unicode'))
 // > i-love-unicode
@@ -49,7 +49,6 @@ slug('string', [{options} || 'replacement']);
 slug.defaults.mode ='pretty';
 slug.defaults.modes['rfc3986'] = {
     replacement: '-',      // replace spaces with replacement
-    symbols: true,         // replace unicode symbols or not
     remove: null,          // (optional) regex to remove characters
     lower: true,           // result in lower case
     charmap: slug.charmap, // replace special characters
@@ -57,7 +56,6 @@ slug.defaults.modes['rfc3986'] = {
 };
 slug.defaults.modes['pretty'] = {
     replacement: '-',
-    symbols: true,
     remove: /[.]/g,
     lower: false,
     charmap: slug.charmap,
@@ -67,8 +65,8 @@ slug.defaults.modes['pretty'] = {
 
 ## browser
 
-When using browserify you might want to remove the symbols table from your bundle by using `--ignore` similar to this:
+When using browserify:
 ```bash
 # generates a standalone slug browser bundle:
-browserify slug.js --detect-globals false --ignore unicode/category/So -s slug > slug-browser.js
+browserify slug.js --detect-globals false -s slug > slug-browser.js
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -2670,11 +2670,6 @@
             "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
             "dev": true
         },
-        "unicode": {
-            "version": "12.1.0",
-            "resolved": "https://registry.npmjs.org/unicode/-/unicode-12.1.0.tgz",
-            "integrity": "sha512-Ty6+Ew21DiYTWLYtd05RF/X4c1ekOvOgANyHbBj0h3MaXpfaGr2Rdmc0hMFuGQLyPLb9cU4ArNxl0bTF5HSzXw=="
-        },
         "uniq": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -21,9 +21,7 @@
     "scripts": {
         "test": "standard && c8 mocha ./test/*.test.* --reporter spec --colors"
     },
-    "dependencies": {
-        "unicode": ">= 0.3.1"
-    },
+    "dependencies": {},
     "devDependencies": {
         "c8": "^7.0.0",
         "mocha": "^7.0.0",

--- a/slug.js
+++ b/slug.js
@@ -1,14 +1,4 @@
 (function (root) {
-// lazy require symbols table
-  var _symbols, removelist
-  function symbols (code) {
-    if (_symbols) return _symbols[code]
-    _symbols = require('unicode/category/So')
-    removelist = ['sign', 'cross', 'of', 'symbol', 'staff', 'hand', 'black', 'white']
-      .map(function (word) { return new RegExp(word, 'gi') })
-    return _symbols[code]
-  }
-
   var base64
   if (typeof window === 'undefined') {
     base64 = function (input) {
@@ -43,7 +33,6 @@
       key = keys[i]
       opts[key] = (key in opts) ? opts[key] : defaults[key]
     }
-    if (typeof opts.symbols === 'undefined') { opts.symbols = defaults.symbols }
 
     var lengths = []
     for (const key in opts.multicharmap) {
@@ -53,7 +42,7 @@
       if (lengths.indexOf(len) === -1) { lengths.push(len) }
     }
 
-    var code; var unicode; var result = ''
+    var result = ''
     for (let char, i = 0, l = string.length; i < l; i++) {
       char = string[i]
       if (!lengths.some(function (len) {
@@ -66,16 +55,6 @@
       })) {
         if (opts.charmap[char]) {
           char = opts.charmap[char]
-          code = char.charCodeAt(0)
-        } else {
-          code = string.charCodeAt(i)
-        }
-        if (opts.symbols && (unicode = symbols(code))) {
-          char = unicode.name.toLowerCase()
-          for (var j = 0, rl = removelist.length; j < rl; j++) {
-            char = char.replace(removelist[j], '')
-          }
-          char = char.trim()
         }
       }
       const allowedChars = opts.mode === 'rfc3986' ? /[^\w\s\-.~]/g : /[^A-Za-z0-9\s]/g
@@ -628,7 +607,6 @@
   slug.defaults.modes = {
     rfc3986: {
       replacement: '-',
-      symbols: true,
       remove: null,
       lower: true,
       charmap: slug.defaults.charmap,
@@ -636,7 +614,6 @@
     },
     pretty: {
       replacement: '-',
-      symbols: true,
       remove: /[.]/g,
       lower: true,
       charmap: slug.defaults.charmap,
@@ -648,23 +625,10 @@
   // Be compatible with different module systems
 
   if (typeof define !== 'undefined' && define.amd) { // AMD
-    // dont load symbols table in the browser
-    for (const key in slug.defaults.modes) {
-      if (!Object.prototype.hasOwnProperty.call(slug.defaults.modes, key)) { continue }
-
-      slug.defaults.modes[key].symbols = false
-    }
     define([], function () { return slug })
   } else if (typeof module !== 'undefined' && module.exports) { // CommonJS
-    symbols() // preload symbols table
     module.exports = slug
   } else { // Script tag
-    // dont load symbols table in the browser
-    for (const key in slug.defaults.modes) {
-      if (!Object.prototype.hasOwnProperty.call(slug.defaults.modes, key)) { continue }
-
-      slug.defaults.modes[key].symbols = false
-    }
     root.slug = slug
   }
 }(this))

--- a/test/slug.test.js
+++ b/test/slug.test.js
@@ -654,32 +654,6 @@ describe('slug', function () {
       assert.strictEqual(slug(`foo ${char} bar baz`), 'foo-bar-baz'))
   })
 
-  it('should replace unicode', function () {
-    const charMap = {
-      '☢': 'radioactive',
-      '☠': 'skull-and-bones',
-      '☤': 'caduceus',
-      '☣': 'biohazard',
-      '☭': 'hammer-and-sickle',
-      '☯': 'yin-yang',
-      '☮': 'peace',
-      '☏': 'telephone',
-      '☔': 'umbrella-with-rain-drops',
-      '☎': 'telephone',
-      '☀': 'sun-with-rays',
-      '★': 'star',
-      '☂': 'umbrella',
-      '☃': 'snowman',
-      '✈': 'airplane',
-      '✉': 'envelope',
-      '✊': 'raised-fist'
-    }
-    for (const char in charMap) {
-      const replacement = charMap[char]
-      assert.strictEqual(slug(`foo ${char} bar baz`), `foo-${replacement}-bar-baz`)
-    }
-  })
-
   it('should replace no unicode when disabled', function () {
     const charMap = '😹☢☠☤☣☭☯☮☏☔☎☀★☂☃✈✉✊'.split('')
     charMap.forEach((char) =>
@@ -695,7 +669,7 @@ describe('slug', function () {
 
   it('should replace lithuanian characters', () => assert.strictEqual(slug('ąčęėįšųūžĄČĘĖĮŠŲŪŽ'), 'aceeisuuzaceeisuuz'))
 
-  it('should replace multichars', () => assert.strictEqual(slug('w/ <3 && sugar || ☠'), 'with-love-and-sugar-or-skull-and-bones'))
+  it('should replace multichars', () => assert.strictEqual(slug('w/ <3 && sugar || cinnamon'), 'with-love-and-sugar-or-cinnamon'))
 
   it('should be flavourable', function () {
     const text = "It's your journey ... we guide you through."


### PR DESCRIPTION
Mapping ✊ to `raised-fist` by default is cute, but not particularly
useful and loading that enormous unicode table is not what people want
by default, I have to imagine. We can document how to add it in for
people who want it, but the primary use case requires a small library
that does languages. Omitting symbols is a good default.